### PR TITLE
ci: speed up workflows + fix onboarding skip

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -85,6 +87,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            biovault/cli
+            syftbox-sdk
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -95,6 +113,16 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.1.38'
+
+      - name: Cache Bun downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/bun
+            ~/Library/Caches/bun
+            ~/AppData/Local/bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
 
       - name: Setup Go (syftbox)
         uses: actions/setup-go@v5
@@ -126,7 +154,17 @@ jobs:
       - name: Install bun dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: cache-playwright-pipelines
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json', 'bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.cache-playwright-pipelines.outputs.cache-hit != 'true'
         run: bunx --bun playwright install --with-deps chromium
 
       # Install biosynth - platform specific
@@ -167,11 +205,21 @@ jobs:
             echo "Warning: Could not download genostats.sqlite"
           }
 
+      - name: Cache bundled dependencies
+        id: cache-bundled-pipelines
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/resources/bundled
+          key: bundled-${{ runner.os }}-${{ hashFiles('scripts/fetch-bundled-deps.sh') }}
+
       - name: Fetch bundled dependencies
+        if: steps.cache-bundled-pipelines.outputs.cache-hit != 'true'
         run: |
           chmod +x scripts/fetch-bundled-deps.sh
           ./scripts/fetch-bundled-deps.sh
-          chmod -R u+rw src-tauri/resources/bundled/ || true
+
+      - name: Ensure bundled dependency permissions
+        run: chmod -R u+rw src-tauri/resources/bundled/ || true
 
       - name: Build syftbox client
         run: |
@@ -237,6 +285,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            biovault/cli
+            syftbox-sdk
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -247,6 +311,16 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.1.38'
+
+      - name: Cache Bun downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/bun
+            ~/Library/Caches/bun
+            ~/AppData/Local/bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
 
       - name: Setup Go (syftbox)
         uses: actions/setup-go@v5
@@ -278,14 +352,34 @@ jobs:
       - name: Install bun dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: cache-playwright-jupyter
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json', 'bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.cache-playwright-jupyter.outputs.cache-hit != 'true'
         run: bunx --bun playwright install --with-deps chromium
 
+      - name: Cache bundled dependencies
+        id: cache-bundled-jupyter
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/resources/bundled
+          key: bundled-${{ runner.os }}-${{ hashFiles('scripts/fetch-bundled-deps.sh') }}
+
       - name: Fetch bundled dependencies
+        if: steps.cache-bundled-jupyter.outputs.cache-hit != 'true'
         run: |
           chmod +x scripts/fetch-bundled-deps.sh
           ./scripts/fetch-bundled-deps.sh
-          chmod -R u+rw src-tauri/resources/bundled/ || true
+
+      - name: Ensure bundled dependency permissions
+        run: chmod -R u+rw src-tauri/resources/bundled/ || true
 
       - name: Build syftbox client
         run: |
@@ -342,6 +436,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            biovault/cli
+            syftbox-sdk
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -352,6 +462,16 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.1.38'
+
+      - name: Cache Bun downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/bun
+            ~/Library/Caches/bun
+            ~/AppData/Local/bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
 
       - name: Setup Go (syftbox)
         uses: actions/setup-go@v5
@@ -383,14 +503,34 @@ jobs:
       - name: Install bun dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: cache-playwright-jupyter-collab
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json', 'bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.cache-playwright-jupyter-collab.outputs.cache-hit != 'true'
         run: bunx --bun playwright install --with-deps chromium
 
+      - name: Cache bundled dependencies
+        id: cache-bundled-jupyter-collab
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/resources/bundled
+          key: bundled-${{ runner.os }}-${{ hashFiles('scripts/fetch-bundled-deps.sh') }}
+
       - name: Fetch bundled dependencies
+        if: steps.cache-bundled-jupyter-collab.outputs.cache-hit != 'true'
         run: |
           chmod +x scripts/fetch-bundled-deps.sh
           ./scripts/fetch-bundled-deps.sh
-          chmod -R u+rw src-tauri/resources/bundled/ || true
+
+      - name: Ensure bundled dependency permissions
+        run: chmod -R u+rw src-tauri/resources/bundled/ || true
 
       - name: Build syftbox client
         run: |
@@ -447,6 +587,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            biovault/cli
+            syftbox-sdk
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -457,6 +613,16 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.1.38'
+
+      - name: Cache Bun downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/bun
+            ~/Library/Caches/bun
+            ~/AppData/Local/bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
 
       - name: Setup Go (syftbox)
         uses: actions/setup-go@v5
@@ -488,14 +654,34 @@ jobs:
       - name: Install bun dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: cache-playwright-multi
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json', 'bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.cache-playwright-multi.outputs.cache-hit != 'true'
         run: bunx --bun playwright install --with-deps chromium
 
+      - name: Cache bundled dependencies
+        id: cache-bundled-multi
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/resources/bundled
+          key: bundled-${{ runner.os }}-${{ hashFiles('scripts/fetch-bundled-deps.sh') }}
+
       - name: Fetch bundled dependencies
+        if: steps.cache-bundled-multi.outputs.cache-hit != 'true'
         run: |
           chmod +x scripts/fetch-bundled-deps.sh
           ./scripts/fetch-bundled-deps.sh
-          chmod -R u+rw src-tauri/resources/bundled/ || true
+
+      - name: Ensure bundled dependency permissions
+        run: chmod -R u+rw src-tauri/resources/bundled/ || true
 
       - name: Build syftbox client
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -142,6 +145,14 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -214,6 +225,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
+        id: cache-playwright
         uses: actions/cache@v4
         with:
           path: |
@@ -222,18 +234,28 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json', 'bun.lock') }}
 
       - name: Install Playwright browsers (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && steps.cache-playwright.outputs.cache-hit != 'true'
         run: bunx --bun playwright install --with-deps chromium
 
       - name: Install Playwright browsers (non-Linux)
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && steps.cache-playwright.outputs.cache-hit != 'true'
         run: bunx --bun playwright install chromium
 
+      - name: Cache bundled dependencies
+        id: cache-bundled
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/resources/bundled
+          key: bundled-${{ runner.os }}-${{ hashFiles('scripts/fetch-bundled-deps.sh') }}
+
       - name: Fetch bundled dependencies
+        if: steps.cache-bundled.outputs.cache-hit != 'true'
         run: |
           chmod +x scripts/fetch-bundled-deps.sh
           ./scripts/fetch-bundled-deps.sh
-          chmod -R u+rw src-tauri/resources/bundled/ || true
+
+      - name: Ensure bundled dependency permissions
+        run: chmod -R u+rw src-tauri/resources/bundled/ || true
 
       - name: Materialize templates
         run: |
@@ -348,9 +370,27 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            biovault/cli
+            syftbox-sdk
 
       - name: Setup Go (syftbox devstack)
         uses: actions/setup-go@v5
@@ -369,22 +409,52 @@ jobs:
         with:
           bun-version: '1.1.38'
 
+      - name: Cache Bun downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/bun
+            ~/Library/Caches/bun
+            ~/AppData/Local/bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
       - name: Install npm dependencies
         run: npm ci
 
       - name: Install bun dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: cache-playwright-profiles
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json', 'bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.cache-playwright-profiles.outputs.cache-hit != 'true'
         run: bunx --bun playwright install --with-deps chromium
 
+      - name: Cache bundled dependencies
+        id: cache-bundled-profiles
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/resources/bundled
+          key: bundled-${{ runner.os }}-${{ hashFiles('scripts/fetch-bundled-deps.sh') }}
+
       - name: Fetch bundled dependencies
+        if: steps.cache-bundled-profiles.outputs.cache-hit != 'true'
         run: |
           export BUNDLED_OS="linux"
           export BUNDLED_ARCH="x86_64"
           chmod +x scripts/fetch-bundled-deps.sh
           ./scripts/fetch-bundled-deps.sh
-          chmod -R u+rw src-tauri/resources/bundled/ || true
+
+      - name: Ensure bundled dependency permissions
+        run: chmod -R u+rw src-tauri/resources/bundled/ || true
 
       - name: Materialize templates
         run: |

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -42,6 +42,11 @@ clone_if_missing() {
     local url="$2"
     local branch="${3:-}"
     local git_args=()
+    local clone_args=()
+
+    if [[ -n "${CI:-}" || -n "${GITHUB_ACTIONS:-}" ]]; then
+        clone_args=(--depth 1 --filter=blob:none)
+    fi
 
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
         local auth_header
@@ -55,9 +60,9 @@ clone_if_missing() {
         echo "Cloning $name to $PARENT_DIR/$name..."
         # Use ${git_args[@]+"${git_args[@]}"} to handle empty arrays with set -u
         if [[ -n "$branch" ]]; then
-            git ${git_args[@]+"${git_args[@]}"} clone -b "$branch" "$url" "$PARENT_DIR/$name"
+            git ${git_args[@]+"${git_args[@]}"} clone ${clone_args[@]+"${clone_args[@]}"} -b "$branch" "$url" "$PARENT_DIR/$name"
         else
-            git ${git_args[@]+"${git_args[@]}"} clone "$url" "$PARENT_DIR/$name"
+            git ${git_args[@]+"${git_args[@]}"} clone ${clone_args[@]+"${clone_args[@]}"} "$url" "$PARENT_DIR/$name"
         fi
     fi
 }

--- a/src/onboarding.js
+++ b/src/onboarding.js
@@ -1639,7 +1639,12 @@ export function initOnboarding({
 				}
 
 				try {
-					await invoke('update_saved_dependency_states')
+					// Do not block the UI on potentially slow dependency checks in CI.
+					void invoke('update_saved_dependency_states', { __wsTimeoutMs: 5000 }).catch(
+						(error) => {
+							console.error('Failed to save skipped state:', error)
+						},
+					)
 				} catch (error) {
 					console.error('Failed to save skipped state:', error)
 				}


### PR DESCRIPTION
## Summary
- Make onboarding skip non-blocking so slow dependency checks don't stall CI.
- Add sccache + rust-cache to nightly + profiles-e2e, and gate Playwright install on cache hits.
- Cache bundled deps and bun downloads, and use shallow clones in CI workspace setup.

- ## Testing
- Not run (workflow/config changes only).