### PR TITLE
Add quick start guide for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo is a kind of mono-repo for BioVault but uses Google's repo tool so the
 ### Workspace deps (repo tool)
 
 - Source of truth: `manifest.xml` pins each dependency repo to a commit.
-- Initialize/sync workspace: `repo init -u <manifest-url> -m manifest.xml` then `repo sync`
+- Initialize/sync workspace: `./repo --init` (recommended) then `./repo sync`
 - Status across repos: `repo status`
 - Branch all repos together: `repo forall -c 'git checkout -B <branch>'`
 - Local helper: `./repo` (tree view), `./repo --init`, `./repo sync`, `./repo pin`, `./repo ssh`
@@ -169,5 +169,6 @@ pinned to specific commits via `manifest.xml`.
 Initialize the workspace using the provided `manifest.xml`:
 
 ```bash
-repo init -u <manifest-url> -m manifest.xml
-repo sync
+./repo --init
+./repo sync
+

--- a/README.md
+++ b/README.md
@@ -152,3 +152,22 @@ With `--test`: adds `cargo test` (Rust) or `pytest` (Python)
 ./repo branch feature/my-change
 # ... commit in each repo ...
 ```
+
+## Quick Start for New Contributors
+
+This repository is part of a multi-repository workspace managed using
+Google’s `repo` tool. Each sub-repository remains independent but is
+pinned to specific commits via `manifest.xml`.
+
+### Prerequisites
+- Git
+- Python 3.9+
+- Rust (stable toolchain)
+- Google `repo` tool
+
+### Initial Setup
+Initialize the workspace using the provided `manifest.xml`:
+
+```bash
+repo init -u <manifest-url> -m manifest.xml
+repo sync


### PR DESCRIPTION
This PR adds a short "Quick Start for New Contributors" section to the README
to clarify workspace setup and common development commands.
No code changes are included.
